### PR TITLE
Compatibility issue with python3 (absolute import)

### DIFF
--- a/extras_mongoengine/__init__.py
+++ b/extras_mongoengine/__init__.py
@@ -1,3 +1,3 @@
-import fields
+from . import fields
 
 __all__ = ('fields')


### PR DESCRIPTION
Relative path import only works with the `from . import something` syntax.